### PR TITLE
Measure FPS by actually counting frames.

### DIFF
--- a/graf_flutter/lib/apps/demo_app.dart
+++ b/graf_flutter/lib/apps/demo_app.dart
@@ -125,7 +125,7 @@ class DemoApp extends StatelessWidget {
 
 String _text() =>
     '''
-Widget count: ${_data.size}       FPS: ${silly.fps.toStringAsFixed(1)}  ${_isMaxMode ? 'Max' : ''}  ${_isSlow ? 'Slow' : ''}`
+Widget count: ${_data.size}       FPS: ${silly.fps.toStringAsFixed(1)} ${_isSlow ? 'Slow' : ''}`
 Times (ms): build ${silly.buildTime.toStringAsFixed(1)}   raster  ${silly.rasterTime.toStringAsFixed(1)}    total ${silly.totalSpan.toStringAsFixed(1)}''';
 
 Widget _createNode(_) => const DecoratedBox(


### PR DESCRIPTION
For a benchmark like this, rather than trying to revers engineer the FPS by looking at the build/raster times, we should literally just count the frames that have occured in the last second. It's still useful to look at the build/raster times, but they don't actually directly reflect the FPS.

This does mean that the FPS never goes above vsync, but I think that's okay for this benchmark. Now, if we are above 59 FPS we add nodes, and if we are below 55 fps we remove nodes.